### PR TITLE
Fix crashes related to eliminated kingdoms and displaying them as non-agression pacts or alliances for active kingdoms

### DIFF
--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/AllianceBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/AllianceBehavior.cs
@@ -1,6 +1,7 @@
-﻿using Diplomacy.DiplomaticAction.Alliance;
+using Diplomacy.DiplomaticAction.Alliance;
 using Diplomacy.DiplomaticAction.WarPeace;
 using Diplomacy.Event;
+using Diplomacy.Extensions;
 
 using System.Linq;
 
@@ -59,7 +60,7 @@ namespace Diplomacy.CampaignBehaviors
 
         private void SupportAlliedKingdom(Kingdom kingdom, Kingdom kingdomToDeclareWarOn)
         {
-            var allies = Kingdom.All.Where(k => kingdom != k && FactionManager.IsAlliedWithFaction(kingdom, k));
+            var allies = KingdomExtensions.AllActiveKingdoms.Where(k => kingdom != k && FactionManager.IsAlliedWithFaction(kingdom, k));
 
             foreach (var ally in allies)
             {
@@ -94,7 +95,7 @@ namespace Diplomacy.CampaignBehaviors
 
         private static void ConsiderFormingAlliances(Kingdom kingdom)
         {
-            var potentialAllies = Kingdom.All
+            var potentialAllies = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != kingdom && FormAllianceConditions.Instance.CanApply(kingdom, k))
                 .ToList();
 
@@ -105,7 +106,7 @@ namespace Diplomacy.CampaignBehaviors
 
         private static void ConsiderBreakingAlliances(Kingdom kingdom)
         {
-            var alliedKingdoms = Kingdom.All
+            var alliedKingdoms = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != kingdom && FactionManager.IsAlliedWithFaction(kingdom, k))
                 .ToList();
 
@@ -127,7 +128,7 @@ namespace Diplomacy.CampaignBehaviors
             if (kingdom is null)
                 return;
 
-            var alliedKingdoms = Kingdom.All
+            var alliedKingdoms = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != kingdom && FactionManager.IsAlliedWithFaction(kingdom, k))
                 .ToList();
 

--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/CivilWarBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/CivilWarBehavior.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Diplomacy.CivilWar;
 using Diplomacy.CivilWar.Actions;
 using Diplomacy.CivilWar.Factions;
@@ -47,7 +47,7 @@ namespace Diplomacy.CampaignBehaviors
             // if war exhaustion is disabled, stop civil wars when the last rebel settlement is taken
             if (!Settings.Instance!.EnableWarExhaustion)
             {
-                foreach (var kingdom in Kingdom.All.Where(x => (x.IsRebelKingdom() || x.HasRebellion()) && x.Fiefs.IsEmpty()).ToList())
+                foreach (var kingdom in KingdomExtensions.AllActiveKingdoms.Where(x => (x.IsRebelKingdom() || x.HasRebellion()) && x.Fiefs.IsEmpty()).ToList())
                 {
                     var rebelFaction = RebelFactionManager.GetRebelFactionForRebelKingdom(kingdom) ?? kingdom.GetRebelFactions().FirstOrDefault();
 

--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/DiplomaticAgreementBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/DiplomaticAgreementBehavior.cs
@@ -1,4 +1,4 @@
-﻿using Diplomacy.DiplomaticAction;
+using Diplomacy.DiplomaticAction;
 using Diplomacy.DiplomaticAction.Alliance;
 using Diplomacy.DiplomaticAction.NonAggressionPact;
 using Diplomacy.Event;
@@ -47,7 +47,7 @@ namespace Diplomacy.CampaignBehaviors
 
             if (MBRandom.RandomFloat < BasePactChance * inverseNormalizedValorLevel)
             {
-                var proposedKingdom = Kingdom.All
+                var proposedKingdom = KingdomExtensions.AllActiveKingdoms
                     .Except(new[] { proposingKingdom })
                     .Where(kingdom => NonAggressionPactConditions.Instance.CanApply(proposingKingdom, kingdom))
                     .Where(kingdom => NonAggressionPactScoringModel.Instance.ShouldFormBidirectional(proposingKingdom, kingdom))

--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/WarExhaustionBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/WarExhaustionBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Diplomacy.DiplomaticAction.WarPeace;
+using Diplomacy.DiplomaticAction.WarPeace;
+using Diplomacy.Extensions;
 
 using Microsoft.Extensions.Logging;
 
@@ -87,7 +88,7 @@ namespace Diplomacy.CampaignBehaviors
         {
             _warExhaustionManager.UpdateDailyWarExhaustionForAllKingdoms();
 
-            foreach (var kingdom in Kingdom.All.ToList())
+            foreach (var kingdom in KingdomExtensions.AllActiveKingdoms.ToList())
             {
                 ConsiderPeaceActions(kingdom);
             }

--- a/src/Bannerlord.Diplomacy/Cheats.cs
+++ b/src/Bannerlord.Diplomacy/Cheats.cs
@@ -1,4 +1,4 @@
-﻿using Diplomacy.CivilWar.Actions;
+using Diplomacy.CivilWar.Actions;
 using Diplomacy.DiplomaticAction.Alliance;
 using Diplomacy.Extensions;
 
@@ -33,7 +33,7 @@ namespace Diplomacy
             Kingdom? kingdom1 = null;
             Kingdom? kingdom2 = null;
 
-            foreach (var k in Kingdom.All)
+            foreach (var k in KingdomExtensions.AllActiveKingdoms)
             {
                 var id = k.Name.ToString().ToLower().Replace(" ", "");
 
@@ -74,7 +74,7 @@ namespace Diplomacy
             Kingdom? kingdom1 = null;
             Kingdom? kingdom2 = null;
 
-            foreach (var k in Kingdom.All)
+            foreach (var k in KingdomExtensions.AllActiveKingdoms)
             {
                 var id = k.Name.ToString().ToLower().Replace(" ", "");
 
@@ -111,7 +111,7 @@ namespace Diplomacy
 
             Kingdom? kingdom1 = null;
 
-            foreach (var k in Kingdom.All)
+            foreach (var k in KingdomExtensions.AllActiveKingdoms)
             {
                 var id = k.Name.ToString().ToLower().Replace(" ", "");
 

--- a/src/Bannerlord.Diplomacy/CivilWar/Actions/ChangeKingdomBannerAction.cs
+++ b/src/Bannerlord.Diplomacy/CivilWar/Actions/ChangeKingdomBannerAction.cs
@@ -1,4 +1,4 @@
-﻿using ColorMine.ColorSpaces;
+using ColorMine.ColorSpaces;
 using ColorMine.ColorSpaces.Comparisons;
 
 using Diplomacy.Event;
@@ -95,7 +95,7 @@ namespace Diplomacy.CivilWar.Actions
             else
             {
                 // choose random unused color from the palette
-                List<uint> currentBackgroundColors = Kingdom.All.Where(x => !x.IsEliminated).Select(x => (uint) PrimaryBannerColorProp.GetValue(x)).ToList();
+                List<uint> currentBackgroundColors = KingdomExtensions.AllActiveKingdoms.Where(x => !x.IsEliminated).Select(x => (uint) PrimaryBannerColorProp.GetValue(x)).ToList();
                 backgroundColor = BannerManager.ColorPalette.Where(x => !currentBackgroundColors.Contains(x.Value.Color)).GetRandomElementInefficiently().Value.Color;
                 sigilColor = GetUniqueSigilColor(backgroundColor);
             }
@@ -111,7 +111,7 @@ namespace Diplomacy.CivilWar.Actions
             uint selectedColor = BannerManager.ColorPalette.Where(x => background.Compare(GetRgb(x.Value.Color), new Cie1976Comparison()) > 40).GetRandomElementInefficiently().Value.Color;
             if (backgroundColor == RebelBackgroundColor)
             {
-                List<uint> currentSigilColors = Kingdom.All.Where(x => !x.IsEliminated && x.IsRebelKingdom()).Select(x => (uint) SecondaryBannerColorProp.GetValue(x)).ToList();
+                List<uint> currentSigilColors = KingdomExtensions.AllActiveKingdoms.Where(x => !x.IsEliminated && x.IsRebelKingdom()).Select(x => (uint) SecondaryBannerColorProp.GetValue(x)).ToList();
                 var colors = BannerManager.ColorPalette.Select(x => x.Value.Color)
                     .Where(x => background.Compare(GetRgb(x), new Cie1976Comparison()) > 40)
                     .Where(x => !currentSigilColors.Contains(x))

--- a/src/Bannerlord.Diplomacy/CivilWar/Actions/StartRebellionAction.cs
+++ b/src/Bannerlord.Diplomacy/CivilWar/Actions/StartRebellionAction.cs
@@ -1,4 +1,5 @@
-﻿using Diplomacy.CivilWar.Factions;
+using Diplomacy.CivilWar.Factions;
+using Diplomacy.Extensions;
 
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +36,7 @@ namespace Diplomacy.CivilWar.Actions
                 rebelFaction.ParentKingdom.Culture,
                 rebelFaction.SponsorClan);
 
-            var kingdom = Kingdom.All.First(x => !x.IsEliminated && x.RulingClan == rebelFaction.SponsorClan);
+            var kingdom = KingdomExtensions.AllActiveKingdoms.First(x => !x.IsEliminated && x.RulingClan == rebelFaction.SponsorClan);
             rebelFaction.StartRebellion(kingdom);
 
             ChangeKingdomBannerAction.Apply(rebelFaction.RebelKingdom!, true);

--- a/src/Bannerlord.Diplomacy/DiplomaticAction/AbstractScoringModel.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/AbstractScoringModel.cs
@@ -1,4 +1,4 @@
-﻿using Diplomacy.Extensions;
+using Diplomacy.Extensions;
 
 using System;
 using System.Linq;
@@ -41,7 +41,7 @@ namespace Diplomacy.DiplomaticAction
 
             // Their Alliances with Enemies
 
-            var alliedEnemies = Kingdom.All
+            var alliedEnemies = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != ourKingdom
                          && k != otherKingdom
                          && FactionManager.IsAlliedWithFaction(otherKingdom, k)
@@ -52,7 +52,7 @@ namespace Diplomacy.DiplomaticAction
 
             // Their Alliances with Neutrals
 
-            var alliedNeutrals = Kingdom.All
+            var alliedNeutrals = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != ourKingdom
                          && k != otherKingdom
                          && FactionManager.IsAlliedWithFaction(otherKingdom, k)
@@ -63,7 +63,7 @@ namespace Diplomacy.DiplomaticAction
             foreach (var alliedNeutral in alliedNeutrals)
                 explainedNum.Add(Scores.ExistingAllianceWithNeutral, CreateTextWithKingdom(SAlliedToNeutral, alliedNeutral));
 
-            var pactEnemies = Kingdom.All
+            var pactEnemies = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != ourKingdom
              && k != otherKingdom
              && DiplomaticAgreementManager.HasNonAggressionPact(otherKingdom, k, out _)
@@ -74,7 +74,7 @@ namespace Diplomacy.DiplomaticAction
 
             // Their Alliances with Neutrals
 
-            var pactNeutrals = Kingdom.All
+            var pactNeutrals = KingdomExtensions.AllActiveKingdoms
                 .Where(k => k != ourKingdom
                          && k != otherKingdom
                          && DiplomaticAgreementManager.HasNonAggressionPact(otherKingdom, k, out _)

--- a/src/Bannerlord.Diplomacy/Extensions/KingdomExtensions.cs
+++ b/src/Bannerlord.Diplomacy/Extensions/KingdomExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Diplomacy.CivilWar;
+using Diplomacy.CivilWar;
 using Diplomacy.CivilWar.Factions;
 
 using System;
@@ -6,11 +6,20 @@ using System.Collections.Generic;
 using System.Linq;
 
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.Library;
 
 namespace Diplomacy.Extensions
 {
     public static class KingdomExtensions
     {
+        public static MBReadOnlyList<Kingdom> AllActiveKingdoms
+        {
+            get
+            {
+                return new MBReadOnlyList<Kingdom>(Kingdom.All.Where((kingdom) => !kingdom.IsEliminated).ToList());
+            }
+        }
+
         public static float GetExpansionism(this Kingdom kingdom)
         {
             return ExpansionismManager.Instance!.GetExpansionism(kingdom);
@@ -73,7 +82,7 @@ namespace Diplomacy.Extensions
         private static float GetMedianStrength()
         {
             float medianStrength;
-            var kingdomStrengths = Kingdom.All.Select(curKingdom => curKingdom.TotalStrength).OrderBy(a => a).ToArray();
+            var kingdomStrengths = KingdomExtensions.AllActiveKingdoms.Select(curKingdom => curKingdom.TotalStrength).OrderBy(a => a).ToArray();
 
             var halfIndex = kingdomStrengths.Length / 2;
 


### PR DESCRIPTION
I was testing some local Modules with Diplomacy enabled and when I've executed an action which destroyed kingdom, game started crashing after DailyClanTick event (during processing of this eliminated kingdom). Before the tick I also noticed another issue with this kingdom being listed in non-agression pacts section of kindoms that had non-agression pact before it got destroyed.