### PR TITLE
Patching should be done when the game starts initialization, because …

### DIFF
--- a/src/Bannerlord.Diplomacy/PatchTools/PatchClass.cs
+++ b/src/Bannerlord.Diplomacy/PatchTools/PatchClass.cs
@@ -62,6 +62,8 @@ namespace Diplomacy.PatchTools
                     throw new PatchCreationException(this);
             }
 
+            public void Remove(Harmony harmony) => harmony.Unpatch(_targetMethod, _patchMethod.MethodInfo);
+
             public override string ToString() => $"{Enum.GetName(typeof(HarmonyPatchType), _type)} patch of "
                                                + $"{_targetMethod.Name} in type {_targetMethod.DeclaringType.Name} ({_targetMethod.DeclaringType.FullName})";
 

--- a/src/Bannerlord.Diplomacy/Patches/RebelKingdomPatches.cs
+++ b/src/Bannerlord.Diplomacy/Patches/RebelKingdomPatches.cs
@@ -8,7 +8,6 @@ using System.Linq;
 
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 
 namespace Diplomacy.Patches

--- a/src/Bannerlord.Diplomacy/SubModule.cs
+++ b/src/Bannerlord.Diplomacy/SubModule.cs
@@ -22,14 +22,12 @@ namespace Diplomacy
 {
     public sealed class SubModule : MBSubModuleBase
     {
-        public static readonly int VersionMajor = 0;
-        public static readonly int VersionMinor = 1;
-        public static readonly int VersionPatch = 1;
-        public static readonly string Version = $"v{VersionMajor}.{VersionMinor}.{VersionPatch}";
+        public static readonly string Version = $"v{typeof(SubModule).Assembly.GetName().Version.ToString(3)}";
 
         public static readonly string Name = typeof(SubModule).Namespace;
         public static readonly string DisplayName = Name;
-        public static readonly string HarmonyDomain = "com.zijistark.bannerlord." + Name.ToLower();
+        public static readonly string MainHarmonyDomain = "bannerlord." + Name.ToLower();
+        public static readonly string CampaignHarmonyDomain = MainHarmonyDomain + ".campaign";
 
         internal static readonly Color StdTextColor = Color.FromUint(0x00F16D26); // Orange
 
@@ -50,6 +48,9 @@ namespace Diplomacy
 
             this.AddSerilogLoggerProvider($"{Name}.log", new[] { $"{Name}.*" }, config => config.MinimumLevel.Is(LogEventLevel.Verbose));
             Log = LogFactory.Get<SubModule>();
+            Log.LogInformation($"Loading {Name} {Version}...");
+
+            PatchManager.ApplyMainPatches(MainHarmonyDomain);
         }
 
         protected override void OnSubModuleUnloaded()
@@ -65,8 +66,6 @@ namespace Diplomacy
             if (!_hasLoaded)
             {
                 _hasLoaded = true;
-
-                Log = LogFactory.Get<SubModule>(); // Upgrade to dedicated log file from closed service registry
                 Log.LogInformation($"Loaded {Name} {Version}!");
 
                 InformationManager.DisplayMessage(new InformationMessage($"Loaded {DisplayName}", StdTextColor));
@@ -79,7 +78,7 @@ namespace Diplomacy
 
             if (game.GameType is Campaign)
             {
-                PatchManager.PatchAll(HarmonyDomain);
+                PatchManager.ApplyCampaignPatches(CampaignHarmonyDomain);
 
                 Events.Instance = new Events();
                 var gameStarter = (CampaignGameStarter) gameStarterObject;
@@ -128,7 +127,7 @@ namespace Diplomacy
 
             if (game.GameType is Campaign)
             {
-                //PatchManager.UnpatchAll();
+                //PatchManager.RemoveCampaignPatches();// Not sure we should do this...
 
                 Log.LogDebug("Campaign session ended.");
             }

--- a/src/Bannerlord.Diplomacy/SubModule.cs
+++ b/src/Bannerlord.Diplomacy/SubModule.cs
@@ -50,8 +50,6 @@ namespace Diplomacy
 
             this.AddSerilogLoggerProvider($"{Name}.log", new[] { $"{Name}.*" }, config => config.MinimumLevel.Is(LogEventLevel.Verbose));
             Log = LogFactory.Get<SubModule>();
-
-            PatchManager.PatchAll(HarmonyDomain);
         }
 
         protected override void OnSubModuleUnloaded()
@@ -81,6 +79,8 @@ namespace Diplomacy
 
             if (game.GameType is Campaign)
             {
+                PatchManager.PatchAll(HarmonyDomain);
+
                 Events.Instance = new Events();
                 var gameStarter = (CampaignGameStarter) gameStarterObject;
 
@@ -127,7 +127,11 @@ namespace Diplomacy
             base.OnGameEnd(game);
 
             if (game.GameType is Campaign)
+            {
+                //PatchManager.UnpatchAll();
+
                 Log.LogDebug("Campaign session ended.");
+            }
         }
     }
 }


### PR DESCRIPTION
…at least on mono the runtime triggers to early static contructor of types that are being patched. If they rely on things that expects the game being initialized (GameTexts.FindText), it will throw