### PR TITLE
fix issue #221

### DIFF
--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/WarExhaustionBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/WarExhaustionBehavior.cs
@@ -169,7 +169,7 @@ namespace Diplomacy.CampaignBehaviors
                     return;
             }
 
-            _warExhaustionManager.AddHeroPerishedWarExhaustion(kingdoms, victim, killer.PartyBelongedTo.Name ?? effector!.Name, detail);
+            _warExhaustionManager.AddHeroPerishedWarExhaustion(kingdoms, victim, killer.PartyBelongedTo?.Name ?? effector!.Name, detail);
         }
 
 


### PR DESCRIPTION
This change resolves #221 
(Due to this fix, game will not crash, if a killer hero is without party)
