### PR TITLE
Relation based war declaration additions

### DIFF
--- a/src/Bannerlord.Diplomacy/DiplomaticAction/GenericConditions/BadRelationCondition.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/GenericConditions/BadRelationCondition.cs
@@ -1,0 +1,42 @@
+﻿using Diplomacy.Extensions;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Localization;
+
+namespace Diplomacy.DiplomaticAction.GenericConditions
+{
+    internal sealed class BadRelationCondition : IDiplomacyCondition
+    {
+        public bool ApplyCondition(Kingdom kingdom,
+                                   Kingdom otherKingdom,
+                                   out TextObject? textObject,
+                                   bool forcePlayerCosts = false,
+                                   bool bypassCosts = false)
+        {
+            textObject = null;
+
+            // if kingdom leaders are friends, do not allow war
+            if (Settings.Instance!.NoWarBetweenFriends && kingdom.Leader.IsFriend(otherKingdom.Leader))
+            {
+                textObject = new TextObject("{=9aaZ8Ed4}Cannot declare war, kingdom leaders are friends.");
+                return false;
+            }
+
+            // if relations are above "good" do not start wars
+            if (Settings.Instance!.NoWarOnGoodRelations && kingdom.Leader.GetRelation(otherKingdom.Leader) >= Settings.Instance!.NoWarOnGoodRelationsThreshold)
+            {
+                textObject = new TextObject("{=Zimavbgw}Cannot declare war, kingdom leaders personal relations are excellent.");
+                return false;
+            }
+
+            // if leading clans have marriages between them => no wars
+            if (Settings.Instance!.NoWarWhenMarriedLeaderClans && kingdom.RulingClan.HasMarriedClanLeaderRelation(otherKingdom.RulingClan))
+            {
+                textObject = new TextObject("{=pXD8Uf2e}Cannot declare war, kingdom leader clans have close family marriages.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Bannerlord.Diplomacy/DiplomaticAction/WarPeace/DeclareWarConditions.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/WarPeace/DeclareWarConditions.cs
@@ -16,7 +16,8 @@ namespace Diplomacy.DiplomaticAction.WarPeace
             new AtPeaceCondition(),
             new HasEnoughTimeElapsedForWarCondition(),
             new NotRebelKingdomCondition(),
-            new NotEliminatedCondition()
+            new NotEliminatedCondition(),
+			new BadRelationCondition()
         };
 
         public DeclareWarConditions() : base(Conditions) { }

--- a/src/Bannerlord.Diplomacy/Extensions/ClanExtensions.cs
+++ b/src/Bannerlord.Diplomacy/Extensions/ClanExtensions.cs
@@ -58,5 +58,12 @@ namespace Diplomacy.Extensions
                 return default;
             }
         }
+		
+		public static bool HasMarriedClanLeaderRelation(this Clan clan, Clan other)
+        {
+            // if any relatives are alive and married to other clan => "related by marriage"
+            return clan.Leader.Spouse?.AllRelatedHeroes().Any(ownSpouseFamMember => ownSpouseFamMember.Clan == other) ?? false
+                || clan.Leader.AllRelatedHeroes().Any(famMember => famMember.IsAlive && (famMember.Spouse?.AllRelatedHeroes().Any(spouseFamMember => spouseFamMember.Clan == other) ?? false));
+        }
     }
 }

--- a/src/Bannerlord.Diplomacy/Extensions/HeroExtensions.cs
+++ b/src/Bannerlord.Diplomacy/Extensions/HeroExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;

--- a/src/Bannerlord.Diplomacy/Extensions/HeroExtensions.cs
+++ b/src/Bannerlord.Diplomacy/Extensions/HeroExtensions.cs
@@ -13,5 +13,39 @@ namespace Diplomacy.Extensions
             var zeroMinTraitLevel = hero.GetTraitLevel(trait) + Math.Abs(trait.MinValue);
             return zeroMinTraitLevel / zeroMinMaxTraitLevel;
         }
+		
+		public static IEnumerable<Hero> AllRelatedHeroes(this Hero inHero, bool includeExSpouses = false)
+        {
+            if (inHero.Father != null)
+            {
+                yield return inHero.Father;
+
+                // father side uncles/aunts are close family
+                foreach (Hero hero3 in inHero.Father.Siblings)
+                    yield return hero3;
+            }
+
+            if (inHero.Mother != null)
+            {
+                yield return inHero.Mother;
+
+                // mother side uncles/aunts are close family
+                foreach (Hero hero4 in inHero.Mother.Siblings)
+                    yield return hero4;
+            }
+
+            if (inHero.Spouse != null)
+                yield return inHero.Spouse;
+
+            foreach (Hero hero in inHero.Children)
+                yield return hero;
+
+            foreach (Hero hero2 in inHero.Siblings)
+                yield return hero2;
+
+            if (includeExSpouses)
+                foreach (Hero hero3 in inHero.ExSpouses)
+                    yield return hero3;
+        }
     }
 }

--- a/src/Bannerlord.Diplomacy/Settings.cs
+++ b/src/Bannerlord.Diplomacy/Settings.cs
@@ -80,6 +80,22 @@ namespace Diplomacy
         [SettingPropertyGroup(HeadingKingdomDiplomacy)]
         public bool PlayerDiplomacyControl { get; set; } = false;
 
+        [SettingPropertyBool(displayName: "{=dRyU9E7Z}No Wars Between Friends", Order = 1001, RequireRestart = false, HintText = "{=XyXJSTKr}If active, kingdom leaders that are friends will not start wars with each other. Default value is enabled.")]
+        [SettingPropertyGroup(HeadingKingdomDiplomacy)]
+        public bool NoWarBetweenFriends { get; set; } = true;
+
+        [SettingPropertyBool(displayName: "{=pWoKQ6HO}No Wars If Good Relations", Order = 1002, RequireRestart = false, HintText = "{=bOuGhbPt}If active, wars between leaders of kingdoms will not be allowed if relations are above war start relations. Default value is enabled.")]
+        [SettingPropertyGroup(HeadingKingdomDiplomacy)]
+        public bool NoWarOnGoodRelations { get; set; } = true;
+
+        [SettingPropertyInteger("{=x0Aoiomr}No Wars Good Relations Threshold", 0, 100, Order = 1003, RequireRestart = false, HintText = "{=aH6rpjt6}The relation value of kingdom leaders after which kingdoms will not start wars with each other. Default value is 30.")]
+        [SettingPropertyGroup(HeadingKingdomDiplomacy)]
+        public int NoWarOnGoodRelationsThreshold { get; set; } = 30;
+
+        [SettingPropertyInteger("{=jwNKk8P7}No Wars When Married", 0, 100, Order = 1004, RequireRestart = false, HintText = "{=xcMzKH48}If active, kingdom leader clans that have a marriage between each other will not start wars. Default value is active.")]
+        [SettingPropertyGroup(HeadingKingdomDiplomacy)]
+        public bool NoWarWhenMarriedLeaderClans { get; set; } = true;
+		
         // Messengers
 
         [SettingPropertyBool("{=nwTyegdV}Enable Messengers Accidents", Order = 0, RequireRestart = false, HintText = "{=T7yybpw3}If enabled, adds a small chance of failure for messengers. The longer the journey, the higher the chance of an accident on the road. Default value is enabled.")]

--- a/src/Bannerlord.Diplomacy/_Module/ModuleData/Languages/std_module_strings_xml.xml
+++ b/src/Bannerlord.Diplomacy/_Module/ModuleData/Languages/std_module_strings_xml.xml
@@ -14,9 +14,12 @@
 
     <string id="v0cDMIcl" text="Cannot declare war on this kingdom. " />
     <string id="Pqk3WuGz" text="Cannot make peace with this kingdom. " />
+    <string id="9aaZ8Ed4" text="Cannot declare war, kingdom leaders are friends." />
+    <string id="Zimavbgw" text="Cannot declare war, kingdom leaders personal relations are excellent." />
+    <string id="pXD8Uf2e" text="Cannot declare war, kingdom leader clans have close family marriages." />
+      
     <string id="zv12jjyW" text="Messenger Sent" />
     <string id="uy86VZX2" text="Messenger Arrived" />
-
 
     <string id="JmgAuONd" text="Oh no. The messenger was ambushed and eaten by a Grue while trying to reach {HERO_NAME}!" />
     <string id="YnRmSele" text="The messenger from {FACTION1_NAME} has arrived at {ADDRESSEE_TEXT}.{BRIBE_TEXT}" />
@@ -136,7 +139,7 @@
     <string id="qbLPBlIv" text="Calradia grows wary of the inexorable expansion of the {EXPANSIONIST_KINGDOM}. A coalition led by the {COALITION_KINGDOM} has been formed to fight them!"/>
 
     <string id="vB3RrMNf" text="The {KINGDOM} has formed a non-aggression pact with the {OTHER_KINGDOM}." />
-    <string id="PdN5g5ub" text="{KINGDOM} has formed an alliance with {OTHER_KINGDOM}!">
+    <string id="PdN5g5ub" text="{KINGDOM} has formed an alliance with {OTHER_KINGDOM}!" />
     <string id="5r6fsHgm" text="Current Score"/>
     <string id="XIBUWDlT" text="Required Score"/>
 
@@ -184,6 +187,14 @@
     <string id="6m1SspFW" text="Enable Player Kingdom Diplomacy Control" />
     <string id="N5EouSSj" text="Gives the player full control over declaring war and making peace in the kingdom they belong to, even if they are just a vassal and not the leader of the kingdom. Default value is disabled." />
     <string id="lhysZl9j" text="Action Tendency" />
+    <string id="dRyU9E7Z" text="No Wars Between Friends" />
+    <string id="XyXJSTKr" text="If active, kingdom leaders that are friends will not start wars with each other. Default value is enabled." />
+    <string id="pWoKQ6HO" text="No Wars If Good Relations" />
+    <string id="bOuGhbPt" text="If active, wars between leaders of kingdoms will not be allowed if relations are above war start relations. Default value is enabled." />
+    <string id="x0Aoiomr" text="No Wars Good Relations Threshold" />
+    <string id="aH6rpjt6" text="The relation value of kingdom leaders after which kingdoms will not start wars with each other. Default value is 30." />
+    <string id="jwNKk8P7" text="No Wars When Married" />
+    <string id="xcMzKH48" text="If active, kingdom leader clans that have a marriage between each other will not start wars. Default value is active." />
 
     <string id="ldLFTs92" text="Costs" />      
     <string id="Ckd1Lsoa" text="Gold Costs" />
@@ -244,7 +255,6 @@
     <string id="e5fHDXgl" text="Corruption" />
     <string id="KWAH0S4h" text="Enable Corruption" />
     <string id="trgnZ0pn" text="Enables corruption, which gradually decays a clan's influence each day when holding too many fiefs. Default value is enabled."/>
-
 
     <string id="ZqQaUIil" text="Expansionism"/>
     <string id="2raR1ZHv" text="Coalitions"/>


### PR DESCRIPTION
This PR adds settings and conditions that prevent war declaration between kingdoms based on:

- Leader friends
- Leader relations
- Marriage for close family of leading clans
