### PR TITLE
Alliance tendency bonus on leader clan marriages

### DIFF
--- a/src/Bannerlord.Diplomacy/DiplomaticAction/AbstractScoringModel.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/AbstractScoringModel.cs
@@ -32,6 +32,11 @@ namespace Diplomacy.DiplomaticAction
             if (!ourKingdom.IsStrong())
                 explainedNum.Add(Scores.BelowMedianStrength, _TWeakKingdom);
 
+            // Marriage score
+
+            if (Settings.Instance!.LeaderClanMarriageAffectsAlliance && ourKingdom.RulingClan.HasMarriedClanLeaderRelation(otherKingdom.RulingClan))
+                explainedNum.Add(Scores.LeaderClanMarriage, CreateTextWithKingdom(SMarriageWithLeaderClan, otherKingdom));
+
             // Common Enemies
 
             var commonEnemies = FactionManager.GetEnemyKingdoms(ourKingdom).Intersect(FactionManager.GetEnemyKingdoms(otherKingdom));
@@ -129,6 +134,8 @@ namespace Diplomacy.DiplomaticAction
             public int Relationship { get; }
 
             public int Tendency { get; }
+
+            public int LeaderClanMarriage { get; }
         }
 
         private static readonly TextObject _TWeakKingdom = new("{=q5qphBwi}Weak Kingdom");
@@ -139,6 +146,7 @@ namespace Diplomacy.DiplomaticAction
         private const string SWarWithKingdom = "{=RqQ4oqvl}War with {KINGDOM}";
         private const string SAllianceWithKingdom = "{=cmOSpfyW}Alliance with {KINGDOM}";
         private const string SPactWithKingdom = "{=t6YhBLj7}Non-Aggression Pact with {KINGDOM}";
+        private const string SMarriageWithLeaderClan = "{=BjkwaNot}Marriage with leading clan of {KINGDOM}";
 
         private const string SCommonEnemy = SWarWithKingdom;
         private const string SAlliedToEnemy = SAllianceWithKingdom;

--- a/src/Bannerlord.Diplomacy/DiplomaticAction/Alliance/AllianceScoringModel.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/Alliance/AllianceScoringModel.cs
@@ -21,7 +21,10 @@
             public int Tendency => Settings.Instance!.AllianceTendency;
 
             public int NonAggressionPactWithEnemy => -1000;
+
             public int NonAggressionPactWithNeutral => -10;
+
+            public int LeaderClanMarriage => 50;
         }
     }
 }

--- a/src/Bannerlord.Diplomacy/DiplomaticAction/NonAggressionPact/NonAggressionPactScoringModel.cs
+++ b/src/Bannerlord.Diplomacy/DiplomaticAction/NonAggressionPact/NonAggressionPactScoringModel.cs
@@ -15,6 +15,7 @@
             public int Tendency => Settings.Instance!.NonAggressionPactTendency;
             public int NonAggressionPactWithEnemy => -20;
             public int NonAggressionPactWithNeutral => -10;
+            public int LeaderClanMarriage => 50;
         }
     }
 }

--- a/src/Bannerlord.Diplomacy/Settings.cs
+++ b/src/Bannerlord.Diplomacy/Settings.cs
@@ -68,6 +68,10 @@ namespace Diplomacy
         [SettingPropertyGroup(HeadingKingdomDiplomacy)]
         public int MinimumAllianceDuration { get; set; } = 42;
 
+        [SettingPropertyBool("{=xXKKRp99}Leader Clan Family Marriage Affects Alliance", Order = 33, RequireRestart = false, HintText = "{=BGS6mUID}If active, will grant a bonus to alliance tendency when leader clans have a family marriage between them. Default value is active.")]
+        [SettingPropertyGroup(HeadingKingdomDiplomacy)]
+        public bool LeaderClanMarriageAffectsAlliance { get; set; } = true;
+
         [SettingPropertyInteger("{=V35hUfcc}Non-Aggression Pact Duration in Days", 0, 1000, Order = 50, RequireRestart = false, HintText = "{=KXLGZEPh}The duration (in days) that a non-aggression pact will last. Default value is 84 (one standard game year).")]
         [SettingPropertyGroup(HeadingKingdomDiplomacy)]
         public int NonAggressionPactDuration { get; set; } = 84;

--- a/src/Bannerlord.Diplomacy/_Module/ModuleData/Languages/std_module_strings_xml.xml
+++ b/src/Bannerlord.Diplomacy/_Module/ModuleData/Languages/std_module_strings_xml.xml
@@ -126,6 +126,7 @@
     <string id="cmOSpfyW" text="Alliance with {ALLIED_KINGDOM}"/>
     <string id="RqQ4oqvl"  text="War with {ENEMY_KINGDOM}"/>
     <string id="t6YhBLj7" text="Non-Aggression Pact with {KINGDOM}" />
+    <string id="BjkwaNot" text="Marriage with leading clan of {KINGDOM}" />
 
     <string id="M4SGjzQP" text="This faction is not interested in forming a non-aggression pact with you."/>
 
@@ -195,7 +196,10 @@
     <string id="aH6rpjt6" text="The relation value of kingdom leaders after which kingdoms will not start wars with each other. Default value is 30." />
     <string id="jwNKk8P7" text="No Wars When Married" />
     <string id="xcMzKH48" text="If active, kingdom leader clans that have a marriage between each other will not start wars. Default value is active." />
-
+    <string id="xcMzKH48" text="If active, kingdom leader clans that have a marriage between each other will not start wars. Default value is active." />
+    <string id="xXKKRp99" text="Leader Clan Family Marriage Affects Alliance" />
+    <string id="BGS6mUID" text="If active, will grant a bonus to alliance tendency when leader clans have a family marriage between them. Default value is active." />
+      
     <string id="ldLFTs92" text="Costs" />      
     <string id="Ckd1Lsoa" text="Gold Costs" />
     <string id="t4hNAoD7" text="Enable Scaling Gold Costs" />


### PR DESCRIPTION
This PR adds a bonus to alliance/nap tendency between kingdoms which leading clans have a (close) family marriage.