### PR TITLE
Fix campaign map war exhaustion widget not appearing on Bannerlord 1.3.x

### DIFF
--- a/src/Bannerlord.Diplomacy/CampaignBehaviors/UIBehavior.cs
+++ b/src/Bannerlord.Diplomacy/CampaignBehaviors/UIBehavior.cs
@@ -23,7 +23,7 @@ namespace Diplomacy.CampaignBehaviors
             }
             else if (Game.Current.GameStateManager.ActiveState is MapState)
             {
-                MapScreen.Instance.AddMapView<MapWarExhaustionIndicatorView>();
+                MapScreen.Instance.AddMapView<GauntletWarExhaustionIndicator>();
                 CampaignEvents.TickEvent.ClearListeners(this);
             }
         }

--- a/src/Bannerlord.Diplomacy/Views/GauntletWarExhaustionIndicator.cs
+++ b/src/Bannerlord.Diplomacy/Views/GauntletWarExhaustionIndicator.cs
@@ -13,7 +13,6 @@ using TaleWorlds.ScreenSystem;
 namespace Diplomacy.Views
 {
     [ViewCreatorModule]
-    [OverrideView(typeof(MapWarExhaustionIndicatorView))]
     [UsedImplicitly]
     public class GauntletWarExhaustionIndicator : MapView
     {


### PR DESCRIPTION
This change fixes the war exhaustion widget failing to appear on the Bannerlord campaign map in version 1.3.x.

`MapScreen.AddMapView<T>()` no longer instantiates override views.
The campaign behavior was adding `MapWarExhaustionIndicatorView`, but the gauntlet
implementation was never created, so `CreateLayout()` never ran and the widget
layer was not added to the map screen.

The fix was to add the defined gauntlet (`GauntletWarExhaustionIndicator`) directly via `AddMapView` instead of `MapWarExhaustionIndicatorView`.

This was only tested on the latest build, 1.3.13, but any 1.3.x version should work just fine with this fix.
<img width="1292" height="590" alt="Screenshot 2026-01-08 214642" src="https://github.com/user-attachments/assets/8f0dee4f-006a-4ab5-886a-679299f7b163" />
